### PR TITLE
Fix ps_mem.py for RedHat 5.9

### DIFF
--- a/scripts/ps_mem.py
+++ b/scripts/ps_mem.py
@@ -237,7 +237,10 @@ def getCmdName(pid, split_args):
     if cmdline[-1] == '' and len(cmdline) > 1:
         cmdline = cmdline[:-1]
     path = proc.path(pid, 'exe')
-    path = os.path.realpath(path) #exception for kernel threads
+    try:
+        path = os.path.realpath(path) #exception for kernel threads
+    except TypeError:
+        pass
     if split_args:
         return " ".join(cmdline)
     if path.endswith(" (deleted)"):


### PR DESCRIPTION
ps_mem.py has a bug running on my RedHat/CentOS 5.9 system. Another person reports the same bug here: http://comments.pixelbeat.org/scripts/

The bug prevents ps_mem.py from printing any info for several key processes. On my system, the previous version of ps_mem.py did not print any info for mysqld, java, or memcached, causing it to severely underreport the amount of memory used by the system.

I traced the problem to this call to os.path.realpath. This call is generated a TypeError exception which is being ignored. Here is an example of the exception that happens from an example Python script:

print os.path.realpath('/proc/18637/exe')
Traceback (most recent call last):
  File "<stdin>", line 1, in ?
  File "/usr/lib64/python2.4/posixpath.py", line 423, in realpath
    resolved = _resolve_link(component)
  File "/usr/lib64/python2.4/posixpath.py", line 440, in _resolve_link
    while islink(path):
  File "/usr/lib64/python2.4/posixpath.py", line 159, in islink
    st = os.lstat(path)
TypeError: lstat() argument 1 must be (encoded string without NULL bytes), not str

This path links to /usr/libexec/mysqld. I'm not exactly sure why lstat is generating this error, as it doesn't for similar paths. It seems quite possible this is a python bug but I'm not aware of which one it is. The python version on this system is 2.4.3. Regardless, this seems like its probably a good workaround as I believe the kernel thread exception you mention here is an OSError exception.
