### PR TITLE
BusyBox sed is unable to process ansi2html scripts

### DIFF
--- a/scripts/ansi2html.sh
+++ b/scripts/ansi2html.sh
@@ -100,9 +100,13 @@ processArg #defaults
 for var in "$@"; do processArg $var; done
 [ "$css_only" ] && [ "$body_only" ] && usage
 
+sedver=$(sed --version 2>/dev/null)
+if test "${sedver#This is not GNU sed}" != "$sedver"; then
+  echo "Error, BusyBox SED is not supported." >&2
+  exit 1
 # Mac OSX's GNU sed is installed as gsed
 # use e.g. homebrew 'gnu-sed' to get it
-if ! sed --version >/dev/null 2>&1; then
+elif [ -z "$sedver" ]; then
   if gsed --version >/dev/null 2>&1; then
     alias sed=gsed
   else


### PR DESCRIPTION
I am not sure which of the [issues in BusyBox `sed`](https://bugs.busybox.net/buglist.cgi?quicksearch=sed) need to fixed to make it work with `ansi2html.sh`, but for now it is better to disable and warn people.